### PR TITLE
Improved multi-platform support

### DIFF
--- a/website_blocker.py
+++ b/website_blocker.py
@@ -1,16 +1,19 @@
 import os 
 import platform 
 
-# Check if the OS is Windows
-is_windows_os = platform.system() == 'Windows'
+is_windows_os = platform.system()=='Windows'
 
-# Change to adjust for your own path 
-if is_windows_os:
-    hosts_path = "C:\\Windows\\System32\\drivers\\etc\\hosts"
-    export_path = "M:\\Downloads\\BlockedWebsiteExports"
-else:
-    hosts_path = "/etc/hosts"
-    export_path = '/home/ubuntu/Downloads/'
+# Determine system type and use correct paths
+match platform.system():
+    case 'Windows':
+        hosts_path = "C:\\Windows\\System32\\drivers\\etc\\hosts"
+        export_path = "M:\\Downloads\\BlockedWebsiteExports"
+    case 'Linux':
+        hosts_path = "/etc/hosts"
+        export_path = '/home/' + os.environ["USER"] + '/Downloads/'
+    case _: # Generic case
+        print("Your system is not supported")
+        exit()
 
 # Localhost IP
 redirect = "127.0.0.1"
@@ -30,11 +33,11 @@ def write(hosts_path, website_list, flag, redirect, is_windows_os) -> None:
                     print(f'\n\tWebsite "{website}" has been added to the block list.')
 
     # Flush DNS cache
+    # DNS caching is normally not enabled by default on most linux distributions,
+    # as well as by default on `systemd-resolved` and `nscd`. If the behavior is
+    # different on your machine, please update this logic
     if is_windows_os:
         os.system('ipconfig /flushdns')
-    else:
-        os.system('sudo systemctl restart nscd')
-
     print("\nDNS cache flushed!")
 
 


### PR DESCRIPTION
There are many hard-coded values which may vary across systems. Additionally, it is important to remember there are more types of systems outside of Windows and Linux.

However, many issues persists with this script.
- Many Linux distributions rely on `/etc/hosts` to define `localhost`. Excerpt from `/etc/hosts` on Fedora Workstation 40:
```
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
```
- There is currently no way to gracefully shut down. It would be nice to add a `quit` option or silently ignore a `KeyboardInterrupt`
- `is_windows_os` is not optimal; `platform.system()` is not that much longer, makes the code more understandable, and has minimal performance overhead.
- Firefox can be wary of the host DNS, and can be configured to supply its own DNS. While this configuration varies between different distributions, it is an important limitation to keep in mind

Very neat project.